### PR TITLE
Add webmaxru WebMCP agent skill to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 ## Tools
 
 - [Collection of WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools/) by Google Chrome Labs
+- [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for implementing and debugging browser WebMCP integrations in JavaScript and TypeScript web apps
 
 ## Tutorials
 


### PR DESCRIPTION
## Summary
- add an external WebMCP implementation/debugging skill for JavaScript and TypeScript web apps
- list it under Tools to match the repo's current grouping for practical WebMCP resources

## Why this fits
The linked skill is a public resource focused on browser WebMCP integrations, including imperative tools, declarative forms, validation, and troubleshooting.