### PR TITLE
Add isainative.dev to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 ## Demos
 
 - 2025.10 [WebMCP demo recording](https://screen.studio/share/hbGudbFm) by Alex Nahas, presented at W3C TPAC 2025
+- [isainative.dev](https://isainative.dev/) - Audit public GitHub repositories for AI coding readiness. Exposing both declarative and imperative WebMCP tools.
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 ## Demos
 
 - 2025.10 [WebMCP demo recording](https://screen.studio/share/hbGudbFm) by Alex Nahas, presented at W3C TPAC 2025
-- [isainative.dev](https://isainative.dev/) - Audit public GitHub repositories for AI coding readiness. Exposing both declarative and imperative WebMCP tools.
+- [isainative.dev](https://isainative.dev/) - Audits public GitHub repositories for AI coding readiness and exposes both declarative and imperative WebMCP tools.
 
 ## Frameworks
 


### PR DESCRIPTION
## Summary
- add the isainative.dev WebMCP-enabled demo application to Demos

## Why this fits
The site is a public WebMCP demo for auditing public GitHub repositories for AI coding readiness, and it exposes both declarative and imperative WebMCP tools.