### PR TITLE
feat: add webmcp-sdk (Tools) and AgentPay x402 payment demo (Demos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 ## Demos
 
 - 2025.10 [WebMCP demo recording](https://screen.studio/share/hbGudbFm) by Alex Nahas, presented at W3C TPAC 2025
+- 2026.03 [AgentPay x402 Payment Demo](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/x402-payment) — AI agent makes x402 micropayments (HTTP 402 Payment Required) through `navigator.modelContext`. Demonstrates both declarative and imperative tool registration with payment wallet UX on Base.
 
 ## Frameworks
 
@@ -58,6 +59,7 @@
 ## Tools
 
 - [Collection of WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools/) by Google Chrome Labs
+- [webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) — W3C WebMCP developer toolkit with TypeScript types, tool helpers, and x402 payment integration. Make any website agent-ready with `navigator.modelContext`.
 
 ## Tutorials
 


### PR DESCRIPTION
## Summary

Two additions to the official W3C WebMCP awesome list following the existing format.

### Tools

**[webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk)** — W3C WebMCP developer toolkit with TypeScript types, tool helpers, and x402 payment integration. Make any website agent-ready with `navigator.modelContext`.

### Demos

**[AgentPay x402 Payment Demo](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/x402-payment)** — An AI agent makes x402 micropayments (HTTP 402 Payment Required) through `navigator.modelContext`. Demonstrates both declarative and imperative tool registration with payment wallet UX on Base. (PR submitted to GoogleChromeLabs/webmcp-tools#96.)

## Why these belong here

- **webmcp-sdk** is a developer tool for building WebMCP-enabled sites — fits the Tools section alongside GoogleChromeLabs/webmcp-tools
- **x402 demo** showcases a new interaction pattern (agent micropayments) not yet represented in the Demos section
- Both follow the established format of the list (concise, date-prefixed for the demo, link-first)

## Checklist

- [x] Link to external resource only (no spec changes)
- [x] Follows convention established in README.md
- [x] Appropriate section (Tools / Demos)
- [x] Code of Conduct acknowledged