### PR TITLE
Add WebConverter under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Collection of WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools/) by Google Chrome Labs
 - [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for implementing and debugging browser WebMCP integrations in JavaScript and TypeScript web apps
 - [Conscriba](https://conscriba.com/) — Automatic WebMCP Creation for AI Agents, Analytics & Tracking
+- [WebConverter](https://webconverter.app/) — Privacy-first, in-browser file converter (images, PDF, audio, video, OCR, 3D models). Every conversion is exposed as a WebMCP tool via `navigator.modelContext` so agents can convert files locally — no uploads, no API keys.
 
 ## Tutorials
 


### PR DESCRIPTION
Adds [WebConverter](https://webconverter.app/) under **Tools**.

It's a privacy-first, in-browser file converter (images, PDF, audio, video, OCR, 3D models). Every conversion is exposed as a WebMCP tool via `navigator.modelContext`, so an agent can convert files locally without uploads or API keys. The full WASM pipeline runs in the user's browser.

Thanks for maintaining the list!