### PR TITLE
Add webmcp.cool and Ask nekuda to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 - [Collection of WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools/) by Google Chrome Labs
 - [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for implementing and debugging browser WebMCP integrations in JavaScript and TypeScript web apps
 - [Conscriba](https://conscriba.com/) — Automatic WebMCP Creation for AI Agents, Analytics & Tracking
+- [webmcp.cool](https://webmcp.cool/) — Live directory of WebMCP-enabled websites with a JSON API for agent-side discovery.
+- [Ask nekuda](https://chromewebstore.google.com/detail/ask-nekuda/amochnnbmnkjjlblolhpddkokhnalkjp) — Chrome side-panel AI assistant that picks up WebMCP tools exposed by the active tab; BYOK or hosted Gemini. [Source](https://github.com/nekuda-ai/nekuda-assistant-web-extension).
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@
 - [Collection of WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools/) by Google Chrome Labs
 - [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for implementing and debugging browser WebMCP integrations in JavaScript and TypeScript web apps
 - [Conscriba](https://conscriba.com/) — Automatic WebMCP Creation for AI Agents, Analytics & Tracking
-- [webmcp.cool](https://webmcp.cool/) — Live directory of WebMCP-enabled websites with a JSON API for agent-side discovery.
-- [Ask nekuda](https://chromewebstore.google.com/detail/ask-nekuda/amochnnbmnkjjlblolhpddkokhnalkjp) — Chrome side-panel AI assistant that picks up WebMCP tools exposed by the active tab; BYOK or hosted Gemini. [Source](https://github.com/nekuda-ai/nekuda-assistant-web-extension).
+- [webmcp.com](https://webmcp.com/) — Live directory of WebMCP-enabled websites with a JSON API for agent-side discovery.
+- [Ask nekuda](https://chromewebstore.google.com/detail/ask-nekuda/amochnnbmnkjjlblolhpddkokhnalkjp) — Chrome side-panel AI assistant that picks up WebMCP tools exposed by the active tab; BYOK or hosted Gemini.
 
 ## Tutorials
 


### PR DESCRIPTION
Two entries appended to the **Tools** section of `README.md`.

## 1. webmcp.cool

[webmcp.cool](https://webmcp.cool/) is a live, curated directory of websites that ship WebMCP tools via `navigator.modelContext`. For each listed site, it surfaces the real tool definitions (`name`, `kind`, `impl`, `description`, `inputSchema`) exactly as an agent would see them.

What makes it useful to the WebMCP community:

- **Agent-facing JSON API** at `/api/v1/sites`, `/api/v1/sites/{host}`, `/api/v1/sites/{host}/tools`, `/api/v1/tools`, `/api/v1/stats`, and a probe endpoint `/api/v1/lookup?url=…`. Full OpenAPI 3.1 spec at <https://webmcp.cool/api/openapi.json>; human-readable reference at <https://webmcp.cool/api-docs>. Discoverable from the home page via `<link rel=\"alternate\" type=\"application/json\">`.
- **Spec-compliant only**: the directory lists only sites that use the official WICG `registerTool` API (and the corresponding declarative `[toolname]` form), so it doubles as a reference set for real-world spec usage.
- **Self-registered WebMCP tools** on the homepage (`about`, `request_listing`, `surprise_me`, `share_on_x`, `share_on_linkedin`), so an agent can list a new site or query the registry through tool calls.
- At time of writing: 31 sites, 143 tools indexed (see `GET /api/v1/stats`).

## 2. Ask nekuda

[Ask nekuda](https://chromewebstore.google.com/detail/ask-nekuda/amochnnbmnkjjlblolhpddkokhnalkjp) ([source](https://github.com/nekuda-ai/nekuda-assistant-web-extension)) is a published Chrome extension (Manifest V3, side-panel) that consumes WebMCP tools registered by the active tab.

- Picks up any tools the page registers via `navigator.modelContext` or the [`@mcp-b/webmcp-polyfill`](https://www.npmjs.com/package/@mcp-b/webmcp-polyfill) and merges them with built-in tools (tab management, history search, current-page reading).
- Page tools are scoped per-tab and prioritised in the prompt; the in-panel \"Tools\" view tags them with a `(page)` badge.
- BYOK (OpenAI / Anthropic / Gemini) or use the hosted Gemini proxy.
- Manifest V3, requires Chrome 113+ for side panel; uses `chrome://flags` *\"WebMCP for testing\"* on Chrome 146+ for native API support.

## Placement

Both entries appended at the end of the existing `## Tools` section, matching the format of the neighbouring `Conscriba` and `agent-skills` entries (link → em-dash → short description).

## Out of scope

No other sections touched. No reflow / reordering of existing entries.