### PR TITLE
Add agent-ready.dev to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@
 
 ## Websites
 
+- [agent-ready.dev](https://agent-ready.dev/) - Scores any website for AI-agent readability against the Vercel Agent Readability Spec, llms.txt, and agent-protocol manifests, and exposes WebMCP tools (`scan_site`, `get_scan`, `ask`) via `navigator.modelContext` so in-browser agents can run scans directly.
+
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)


### PR DESCRIPTION
Adds [agent-ready.dev](https://agent-ready.dev) to the list.

**Why it fits:** agent-ready.dev is a live site that implements WebMCP — it registers its own tools (`scan_site`, `get_scan`, `ask`) on `navigator.modelContext` (feature-detected, no-op where unsupported), so in-browser agents can scan any public URL for AI-agent readability and get back a 0–100 score with per-check fixes. It scores sites against the Vercel Agent Readability Spec, llmstxt.org, and agent-protocol manifests.

- Single entry, follows the existing format in the section.
- Public, free to use, no signup required to scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)