### PR TITLE
Add Scholar Sidekick to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@
 
 ## Websites
 
+- [Scholar Sidekick](https://scholar-sidekick.com/) - Resolves scholarly identifiers (DOI, PMID, arXiv, ISBN…) and verifies citations, exposing six WebMCP tools (`resolveIdentifier`, `formatCitation`, `exportCitation`, `verifyCitation`, `checkRetraction`, `checkOpenAccess`) via `navigator.modelContext`, so in-browser agents can format citations and check retraction, open-access, and fabrication status directly.
+
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)


### PR DESCRIPTION
Adds [Scholar Sidekick](https://scholar-sidekick.com) to the list.

**Why it fits:** Scholar Sidekick is a live site that implements WebMCP — it registers six tools (`resolveIdentifier`, `formatCitation`, `exportCitation`, `verifyCitation`, `checkRetraction`, `checkOpenAccess`) on `navigator.modelContext` (feature-detected via an inline script, no-op where unsupported), so in-browser agents can resolve scholarly identifiers (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode), format citations in 10,000+ CSL styles, export bibliographies, and check retraction, open-access, and citation-fabrication status — without DOM scraping.

- Single entry, follows the existing format in the section.
- Public, free to use, no signup required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)