### PR TITLE
Add Shopware WebMCP Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@
 
 ## Frameworks
 
+- [Shopware WebMCP Plugin](https://github.com/agentic-commerce-lab/webmcp-plugin) - Adds WebMCP support to storefronts built with Shopware, an open-source ecommerce platform.
+
 ## Presentations
 
 ## Testimonials


### PR DESCRIPTION
Adds the Shopware WebMCP Plugin to the Frameworks section.\n\nShopware is an open-source ecommerce platform, and this plugin adds WebMCP support to storefronts built with Shopware.\n\nValidation: checked the rendered README list format and kept the change scoped to README.md, as requested in the contribution guidelines.