### PR TITLE
Add NaCzarter to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@
 
 ## Websites
 
+- [NaCzarter](https://naczarter.pl) - Yacht charter on the Masurian Lakes, Poland. Registers WebMCP tools to search availability, quote a charter and book it; live in production under the Chrome 149 origin trial.
+
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)


### PR DESCRIPTION
The Websites section was empty, so here's a first entry. We run a yacht-charter business on the Masurian Lakes (naczarter.pl) and put WebMCP tools into production this week — an agent can search availability, get a live quote and start a booking. Kept it to one line to match the convention in the rest of the file; happy to adjust the wording.