### PR TITLE
Add Stacktree (Websites) and agentk (Frameworks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 
 ## Frameworks
 
+- [agentk](https://github.com/stevysmith/agentk) - Command palette library (a cmdk fork) where tools defined once as JSON Schema become human-facing forms and WebMCP registrations; handles the `navigator.modelContext` to `document.modelContext` move and AbortSignal-based unregistration.
 - [Shopware WebMCP Plugin](https://github.com/agentic-commerce-lab/webmcp-plugin) - Adds WebMCP support to storefronts built with Shopware, an open-source ecommerce platform.
 
 ## Presentations
@@ -77,6 +78,8 @@
 - 2025.10 [WebMCP demo recording](https://screen.studio/share/hbGudbFm) by Alex Nahas, presented at W3C TPAC 2025
 
 ## Websites
+
+- [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
 
 ## License
 


### PR DESCRIPTION
Adds stacktr.ee under Websites — a production deployment: the dashboard and docs expose site-management tools via WebMCP (registered on document.modelContext, Chrome origin trial), sharing one catalog between the human command palette and in-browser agents.

Adds agentk under Frameworks — the MIT-licensed palette library behind it (cmdk fork; JSON Schema tools become both auto-generated forms and WebMCP registrations).