### PR TITLE
Add WindowsForum to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@
 
 ## Websites
 
+- [WindowsForum](https://windowsforum.com/) - Windows community forum exposing 20+ read-only tools and confirmation-gated member actions via `document.modelContext` (Chrome and Edge origin trials), plus a declarative search form and a [`.well-known/webmcp.json`](https://windowsforum.com/.well-known/webmcp.json) discovery document
+
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)


### PR DESCRIPTION
Adds windowsforum.com to the (currently empty) Websites section — a production Windows community forum with WebMCP tools live for real visitors:

- 20+ read-only tools plus confirmation-gated member actions registered via `document.modelContext` (`registerTool`), shipped under both the Chrome and Edge origin trials
- Declarative search form (`toolname`/`tooldescription`/`toolautosubmit`)
- Static discovery at [.well-known/webmcp.json](https://windowsforum.com/.well-known/webmcp.json) and an agent-skills doc for JS-inspecting agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)