### PR TITLE
Add webmcpify to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for implementing and debugging browser WebMCP integrations in JavaScript and TypeScript web apps
 - [Conscriba](https://conscriba.com/) — Automatic WebMCP Creation for AI Agents, Analytics & Tracking
 - [WSG WebMCP Experiment](https://mgifford.github.io/wsg-webmcp-experiment/) - An effort to learn about WebMCP by applying it to the [Web Sustainability Guidelines](https://github.com/w3c/sustainableweb-wsg)
+- [webmcpify](https://github.com/TueJon/webmcpify) - Agent skill that integrates WebMCP into an existing web app end to end — inventories the app, proposes a tool manifest for approval, integrates the tools, then verifies each one in a real browser and heals failures
 
 ## Tutorials
 


### PR DESCRIPTION
Adds [webmcpify](https://github.com/TueJon/webmcpify) to the Tools section.

webmcpify is an MIT-licensed agent skill (installable in Claude Code, Codex, Cursor, and other coding agents) that integrates WebMCP into an existing web application end to end: it inventories the app, proposes a tool manifest for human approval, integrates the tools against `document.modelContext`, then verifies each tool by executing it in a real browser and heals failures. It vendors a small zero-dependency runtime (feature-detected, so apps stay behaviorally unchanged in browsers without WebMCP) and follows the patterns from GoogleChromeLabs/webmcp-tools.