### PR TITLE
Add admintoolkit.io to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for implementing and debugging browser WebMCP integrations in JavaScript and TypeScript web apps
 - [Conscriba](https://conscriba.com/) — Automatic WebMCP Creation for AI Agents, Analytics & Tracking
 - [WSG WebMCP Experiment](https://mgifford.github.io/wsg-webmcp-experiment/) - An effort to learn about WebMCP by applying it to the [Web Sustainability Guidelines](https://github.com/w3c/sustainableweb-wsg)
+- [admintoolkit.io](https://admintoolkit.io/) - A suite of 24 read-only WebMCP tools for infrastructure diagnostics, including a WebMCP tool validator.
 
 ## Tutorials
 


### PR DESCRIPTION
Adds admintoolkit.io to the Tools section.

admintoolkit.io provides 24 read-only WebMCP tools for infrastructure diagnostics, including a WebMCP tool validator.

Validation: confirmed the live manifest exposes 24 tools with `readOnlyHint: true`, the site uses `document.modelContext.registerTool(...)`, and the validator page is publicly accessible. The change is scoped to one README.md entry, as requested by the contribution guidelines.
