### PR TITLE
Add webmcp-django to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 ## Frameworks
 
 - [Shopware WebMCP Plugin](https://github.com/agentic-commerce-lab/webmcp-plugin) - Adds WebMCP support to storefronts built with Shopware, an open-source ecommerce platform.
+- [webmcp-django](https://github.com/seunghan91/webmcp-django) - Django integration for WebMCP: Origin-Trial token middleware and template tags for the declarative form API.
 
 ## Presentations
 


### PR DESCRIPTION
Adds [webmcp-django](https://github.com/seunghan91/webmcp-django) — Django integration for WebMCP, extracted from a production Rails+WebMCP rollout and ported to Django:

- `OriginTrialMiddleware` — serves the `Origin-Trial` token header from settings (no-op when unset, preserves existing headers)
- `{% webmcp_tool %}` / `{% webmcp_param %}` template tags emitting the declarative API attributes (`toolname`/`tooldescription`/`toolparamdescription`), with unconditional HTML escaping
- Published on PyPI as `webmcp-django` 0.1.0, MIT, tested (10 test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)