### PR TITLE
Add webmcp-go to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 ## Frameworks
 
 - [Shopware WebMCP Plugin](https://github.com/agentic-commerce-lab/webmcp-plugin) - Adds WebMCP support to storefronts built with Shopware, an open-source ecommerce platform.
+- [webmcp-go](https://github.com/seunghan91/webmcp-go) - Go net/http middleware that serves the WebMCP Origin-Trial token header.
 
 ## Presentations
 


### PR DESCRIPTION
Adds [webmcp-go](https://github.com/seunghan91/webmcp-go) — a small Go `net/http` middleware that serves the WebMCP `Origin-Trial` token header (pass-through when the token is empty, preserves headers set by earlier middleware). MIT, tested, tagged v0.1.0 (`go get github.com/seunghan91/webmcp-go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)