### PR TITLE
Add QR Code Crafter to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 
 - [Demos](https://github.com/GoogleChromeLabs/webmcp-tools/#demos) by Google Chrome Labs
 - [Demos](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md#demos) by 3rd-party developers
+- [QR Code Crafter Readability Lab](https://qrcodecrafter.com/qr-code-readability-lab) - Uses declarative and imperative WebMCP tools to generate QR exports, run bounded preflight checks, and verify exact decoding before returning assets.
 - [isainative.dev](https://isainative.dev/) - Audits public GitHub repositories for AI coding readiness and exposes both declarative and imperative WebMCP tools.
 
 ## Frameworks


### PR DESCRIPTION
Adds the QR Code Crafter Readability Lab as a production WebMCP demo.

The page exposes declarative and runtime WebMCP tools for QR export generation, bounded preflight checks, and exact final-asset decoding. A fresh production verification on 14 August 2026 confirmed the declarative form, valid schemas, Origin Trial signal, and verified final-asset workflow.

Disclosure: I maintain QR Code Crafter for Brand Aspect Ltd.