### PR TITLE
Add Airport Lounge List to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 
 ## Websites
 
+- [Airport Lounge List](https://airportloungelist.com) - Airport lounge directory. Every page registers imperative WebMCP tools to search lounges, list an airport's lounges by IATA code, read the current page as Markdown and move around the site. Each tool is backed by the Markdown twin the page already serves, so agents and humans read the same source.
 - [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
 
 ## License


### PR DESCRIPTION
Adds [Airport Lounge List](https://airportloungelist.com) to the Websites section.

It is a production airport lounge directory. Every page registers imperative `navigator.modelContext` tools:

- `get_current_page` — read the current page as Markdown
- `search_lounges` — search the directory by name, airport, city, country or IATA code
- `get_airport_lounges` — list an airport's lounges by IATA code
- `get_lounge_details` — look up one lounge by slug
- `navigate_to` — move to another page on the site

Each tool reads the Markdown twin the page already serves, so the agent and the human see the same content. Tools re-register on Turbo navigation and unregister through an `AbortSignal`.

Kept alphabetical within the section.