### PR TITLE
Add FlightQueue to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 
 ## Websites
 
+- [FlightQueue](https://flightqueue.com) - Airport queue intelligence. Airport pages expose live security checkpoint waits, recent traveller-submitted wait reports and current FAA ground stops over WebMCP, plus a write tool to file a wait the traveller has just observed. Tools call same-origin endpoints with the visitor's own session, so an in-browser agent gets exactly the entitlements the signed-in user has. Declared at [/.well-known/webmcp.json](https://flightqueue.com/.well-known/webmcp.json).
 - [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
 
 ## License


### PR DESCRIPTION
Adds FlightQueue to the Websites section.

FlightQueue registers four tools on `navigator.modelContext` from its airport pages:

- `get_airport_security_wait` — live checkpoint waits, by terminal and checkpoint
- `get_airport_crowd_reports` — recent traveller-submitted waits
- `get_faa_delays` — current US ground stops and delay programmes
- `submit_airport_wait_report` — files a wait the traveller has just observed

Each tool calls a same-origin endpoint with the visitor's own cookies, so an in-browser agent inherits exactly the entitlements of the signed-in user rather than needing a separate key.

The tool list is also declared statically at [/.well-known/webmcp.json](https://flightqueue.com/.well-known/webmcp.json), so it is readable without a browser that has the API. The manifest and the page registration are generated from one source, so they cannot drift.