### PR TITLE
Add sms-florin to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 ## Websites
 
 - [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
+- [sms-florin](https://flo-voice1.com/esim) - eSIM and virtual phone number store. WebMCP tools are registered on the live Stripe checkout flow (not a separate demo), so an agent browses plans and completes a real purchase through the same code path a human uses. [Integration source](https://github.com/flovoice53-tech/sms-florin-webmcp-demo)
 
 ## License
 


### PR DESCRIPTION
Adding sms-florin (eSIM / virtual phone number store) to the Websites section.

Context: this is a real WebMCP integration on a live commercial product's actual Stripe checkout — not a separate toy demo built to showcase the standard. The tools let an agent browse plans and complete a real purchase through the same checkout code path a human uses.

The integration code (not the full commercial app) is in a standalone MIT-licensed repo: https://github.com/flovoice53-tech/sms-florin-webmcp-demo

Happy to adjust wording/placement to match the list's conventions.