### PR TITLE
Add simple-webmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 
 - [agentk](https://github.com/stevysmith/agentk) - Command palette library (a cmdk fork) where tools defined once as JSON Schema become human-facing forms and WebMCP registrations; handles the `navigator.modelContext` to `document.modelContext` move and AbortSignal-based unregistration.
 - [Shopware WebMCP Plugin](https://github.com/agentic-commerce-lab/webmcp-plugin) - Adds WebMCP support to storefronts built with Shopware, an open-source ecommerce platform.
+- [simple-webmcp](https://github.com/emingure/simple-webmcp) - Turns existing JavaScript and TypeScript functions into callable WebMCP tools via `webmcp(fn)`, avoiding a separate tool layer while supporting schema patching, React lifecycle helpers, and execution hooks for approvals, HITL flows, and analytics.
 
 ## Presentations
 


### PR DESCRIPTION
Adds `simple-webmcp`, a function-first WebMCP library for turning existing JavaScript/TypeScript functions into callable WebMCP tools.

The main focus is developer experience: `webmcp(fn)` avoids maintaining a separate tool implementation while supporting schema patching, React lifecycle integration, and execution hooks that can be used for approvals, HITL flows, and analytics.

Links:
- Repository: https://github.com/emingure/simple-webmcp
- npm: https://www.npmjs.com/package/simple-webmcp
- Docs: https://emingure.github.io/simple-webmcp/
- Demo: https://emingure.github.io/simple-webmcp/demo/
