### PR TITLE
Add Archipelago to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 
 ## Websites
 
+- [Archipelago](https://warrenperez.com/en/archipelago/) - Maps a Notion workspace as a nautical chart, entirely in the browser. Four WebMCP tools let an agent draw the chart from structured data, read it back, highlight a computed set of databases, and annotate islands - on the same map the human is watching.
 - [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
 
 ## License


### PR DESCRIPTION
Adding [Archipelago](https://warrenperez.com/en/archipelago/) to the Websites section.

Archipelago maps a Notion workspace as a nautical chart, entirely in the browser (nothing is uploaded). It registers four WebMCP tools — `archipelago_draw_map`, `archipelago_read_map`, `archipelago_select`, `archipelago_annotate` — so an agent can draw the chart from structured workspace data, read it back, highlight a computed set of databases, and annotate islands, on the same map the human is watching.

- Live (works today in ChatGPT's built-in browser and Chrome with the WebMCP origin trial): https://warrenperez.com/en/archipelago/
- Agent-facing reference: https://warrenperez.com/archipelago/agents.txt
- Open source (MIT): https://github.com/warrenperez/archipelago
- 3-min voice demo: https://www.youtube.com/watch?v=r9rdttiTVAc

Entry added in alphabetical order, following the file's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)