### PR TITLE
Add a WebMCP build write-up to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 ## Blogs
 
 - 2026.02 [WebMCP: The Web Standard That Makes Every Website a Tool for Agents](https://www.arcade.dev/blog/web-mcp-alex-nahas-interview) by RL Nabors, based on Alex Nahas interview
+- 2026.09 [I added WebMCP to a live Stripe checkout in ~40 lines](https://dev.to/flovoice53tech/i-added-webmcp-to-a-live-stripe-checkout-in-40-lines-4ekk) by Florin Arsenie, on adding WebMCP to a product that already takes real money
 
 ## Community
 


### PR DESCRIPTION
Adds one Blogs entry: a short write-up on adding WebMCP tools to a checkout that already takes real money, reusing the same code path as the human Buy button. https://dev.to/flovoice53tech/i-added-webmcp-to-a-live-stripe-checkout-in-40-lines-4ekk

The sms-florin Websites entry that PR #33 also included is already in via #27, so this is just the one Blogs line.