### PR TITLE
Add CliDeck Network Evidence Workbench demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 
 - [Demos](https://github.com/GoogleChromeLabs/webmcp-tools/#demos) by Google Chrome Labs
 - [Demos](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md#demos) by 3rd-party developers
+- [CliDeck MCP — Network Evidence Workbench](https://mcp.clideck.com/demo) - Live, read-only, version-aware network knowledge demo exposing deterministic lookup, change review, snapshot analysis, upgrade guidance, and topology analysis through WebMCP tools ([source](https://github.com/SmartRoot7/clideck-mcp)).
 - [isainative.dev](https://isainative.dev/) - Audits public GitHub repositories for AI coding readiness and exposes both declarative and imperative WebMCP tools.
 
 ## Frameworks


### PR DESCRIPTION
Adds CliDeck MCP to the Demos section using the existing list format. The live read-only workbench exposes version-aware networking knowledge workflows through WebMCP, and the entry links to its source.

Disclosure: submitted on behalf of the CliDeck maintainer.