### PR TITLE
Add TrickyBird to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [agent-ready.dev](https://agent-ready.dev/) - Scores any website for AI-agent readability against the Vercel Agent Readability Spec, llms.txt, and agent-protocol manifests, and exposes WebMCP tools (`scan_site`, `get_scan`, `ask`) via `navigator.modelContext` so in-browser agents can run scans directly.
 - [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
 - [sms-florin](https://flo-voice1.com/esim) - eSIM and virtual phone number store. WebMCP tools are registered on the live Stripe checkout flow (not a separate demo), so an agent browses plans and completes a real purchase through the same code path a human uses. [Integration source](https://github.com/flovoice53-tech/sms-florin-webmcp-demo)
+- [TrickyBird](https://trickybird.com) - Web proxy whose home page registers one imperative tool, `open_site`, through `document.modelContext`, so an in-browser agent can hand it an address and the tab navigates to the proxied page.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@
 - [agent-ready.dev](https://agent-ready.dev/) - Scores any website for AI-agent readability against the Vercel Agent Readability Spec, llms.txt, and agent-protocol manifests, and exposes WebMCP tools (`scan_site`, `get_scan`, `ask`) via `navigator.modelContext` so in-browser agents can run scans directly.
 - [Stacktree](https://stacktr.ee) - Agent-first HTML hosting. The production dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP from a command palette, so humans and in-browser agents share one tool catalog.
 - [sms-florin](https://flo-voice1.com/esim) - eSIM and virtual phone number store. WebMCP tools are registered on the live Stripe checkout flow (not a separate demo), so an agent browses plans and completes a real purchase through the same code path a human uses. [Integration source](https://github.com/flovoice53-tech/sms-florin-webmcp-demo)
-- [TrickyBird](https://trickybird.com) - Web proxy whose home page registers one imperative tool, `open_site`, through `document.modelContext`, so an in-browser agent can hand it an address and the tab navigates to the proxied page.
+- [TrickyBird](https://trickybird.com/faq#faq-webmcp) - Web proxy whose home page registers one imperative tool, `open_site`, through `document.modelContext`, so an in-browser agent can hand it an address and the tab navigates to the proxied page.
 
 ## License
 


### PR DESCRIPTION
Adds TrickyBird to the Websites section.

TrickyBird is a web proxy. Its home page registers one tool, `open_site`, through `document.modelContext.registerTool`. It takes one string, the address, validates it, and the tab navigates to the proxied page. The result is one of three fixed strings: `ok`, `invalid_url` or `refused`.

Disclosure: I maintain TrickyBird and I'm submitting my own site.

One detail that may interest the group, since it runs against the grain. Through a proxy every frame is same-origin, so the `self` default of the `tools` policy isolates nothing: a frame from the site a reader opened could register tools into the page the agent holds. So our gateway sends `tools=()` on every document it serves, and a proxied document can register no tools. The tool exists only on our own origin.
