### PR TITLE
Add scvd.store to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - 2025.10 [WebMCP demo recording](https://screen.studio/share/hbGudbFm) by Alex Nahas, presented at W3C TPAC 2025
 
 ## Websites
+- [scvd.store](https://scvd.store) - Evidence observatory and general store for agentic commerce. WebMCP tools (`read_store_guide`, `preflight_endpoint`, `check_conformance`, `verify_artifact`) mirror the store's free x402 conformance-check and endpoint-preflight instruments, registered read-only via `navigator.modelContext` alongside the store's live x402 payment shelf.
 
 - [Archipelago](https://warrenperez.com/en/archipelago/) - Maps a Notion workspace as a nautical chart, entirely in the browser. Four WebMCP tools let an agent draw the chart from structured data, read it back, highlight a computed set of databases, and annotate islands - on the same map the human is watching.
 - [Scholar Sidekick](https://scholar-sidekick.com/integrations/webmcp) - Resolves scholarly identifiers (DOI, PMID, arXiv, ISBN…) and verifies citations, exposing seven WebMCP tools (`verifyCitation`, `auditBibliography`, `checkRetraction`, `checkOpenAccess`, `resolveIdentifier`, `formatCitation`, `exportCitation`) via `navigator.modelContext`, so in-browser agents can verify a citation or audit a whole bibliography, format citations, and check retraction and open-access status directly.


### PR DESCRIPTION
## What

Adds scvd.store to the Websites section: a live x402 general store for AI agents that also ships a parallel WebMCP surface.

## Why it fits

The site registers four read-only tools via `navigator.modelContext`:
- `read_store_guide` — the store's own machine-readable guide/menu
- `preflight_endpoint` — free pre-payment simulation of any x402 endpoint's `accepts` selection logic (what a configured x402 client would sign, before any signature exists)
- `check_conformance` — free x402 v2 conformance checking against any issuer's signed offers/receipts, including competitors'
- `verify_artifact` — independent verification of a signed certificate against the store's published key

WebMCP tools here are deliberately read-only by design (nothing that moves money registers on `navigator.modelContext`); the store's own x402 payment flow is the separate, funded path. This is a live production site, not a demo — the tools back the same free conformance/preflight desk the store already runs at `/api/conformance` and `/api/before-you-pay/v1`.

## Checklist

- [x] Live, working site (not a demo/prototype)
- [x] Actual WebMCP tools registered (not a stub)
- [x] One entry, one PR
- [x] Format matches existing README convention
