### PR TITLE
Add Settled Estate browser WebMCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@
 
 ## Websites
 
+- [Settled Estate](https://settledestate.com/webmcp/) - Public probate and estate-guidance search, dated comparisons of five reviewed will makers, and state executor-compensation calculators. Browser WebMCP tools update the same visible controls used manually, with source dates, price conditions and explicit unknowns. Financial inputs stay out of shared URLs.
+
 - [Archipelago](https://warrenperez.com/en/archipelago/) - Maps a Notion workspace as a nautical chart, entirely in the browser. Four WebMCP tools let an agent draw the chart from structured data, read it back, highlight a computed set of databases, and annotate islands - on the same map the human is watching.
 - [Scholar Sidekick](https://scholar-sidekick.com/integrations/webmcp) - Resolves scholarly identifiers (DOI, PMID, arXiv, ISBN…) and verifies citations, exposing seven WebMCP tools (`verifyCitation`, `auditBibliography`, `checkRetraction`, `checkOpenAccess`, `resolveIdentifier`, `formatCitation`, `exportCitation`) via `navigator.modelContext`, so in-browser agents can verify a citation or audit a whole bibliography, format citations, and check retraction and open-access status directly.
 - [agent-ready.dev](https://agent-ready.dev/) - Scores any website for AI-agent readability against the Vercel Agent Readability Spec, llms.txt, and agent-protocol manifests, and exposes WebMCP tools (`scan_site`, `get_scan`, `ask`) via `navigator.modelContext` so in-browser agents can run scans directly.


### PR DESCRIPTION
Adds Settled Estate to the live websites/examples list. I maintain the site.

The production integration uses Chrome's current `document.modelContext` API. Three site-wide entry points search public guidance, compare five reviewed will makers, and open a state calculator; `estimate_executor_pay` is registered on the 40 published state calculator pages. The tools reuse the manual UI and business rules and show results before completing. Source dates, billing conditions, editorial provenance and unknown values stay explicit.

- Documentation and manual entry points: https://settledestate.com/webmcp/
- Generated definitions (documentation, not a remote endpoint): https://settledestate.com/webmcp-tools.json
- Example prompt: “Find Pennsylvania guides about letters testamentary.”
- Another example: “Compare FreeWill and Trust & Will.”

This is experimental browser WebMCP, requiring an enabled compatible browser. It is general information, not legal advice. No account, model API or purchase is needed to run the site tools.

Production checks on September 8, 2026 used Chrome 152’s real native API: all 17 browser journey checks and all 40 calculator schemas passed. Six mobile UI surfaces had zero axe WCAG A/AA violations. Inputs, page navigation, source/price conditions and agreement with the visible UI were checked. These are deterministic browser checks, not a model benchmark.
